### PR TITLE
feat: unify interactive primary styles

### DIFF
--- a/src/renderer/src/assets/css/index.css
+++ b/src/renderer/src/assets/css/index.css
@@ -72,3 +72,9 @@ body {
 ::-webkit-scrollbar-thumb:hover {
   background-color: theme('colors.gray.600');
 }
+
+@layer components {
+  .interactive-primary {
+    @apply hover:bg-primary-600 active:bg-primary-600 disabled:bg-primary-400 disabled:cursor-not-allowed group-aria-[disabled=false]:hover:bg-primary-600 group-aria-[disabled=false]:active:bg-primary-600 group-aria-[disabled=true]:bg-primary-400 group-aria-[disabled=true]:cursor-not-allowed;
+  }
+}

--- a/src/renderer/src/components/Checkbox.tsx
+++ b/src/renderer/src/components/Checkbox.tsx
@@ -21,10 +21,11 @@ export const Checkbox = forwardRef<HTMLButtonElement, TCheckboxProps>(
       <RadixCheckbox.Root
         ref={ref}
         className={StyleHelper.mergeStyles(
-          'flex max-h-[1.125rem] min-h-[1.125rem] min-w-[1.125rem] max-w-[1.125rem] items-center justify-center rounded-sm border-2',
+          'interactive-primary flex max-h-[1.125rem] min-h-[1.125rem] min-w-[1.125rem] max-w-[1.125rem] items-center justify-center rounded-sm border-2',
           {
-            'cursor-not-allowed border-gray-300': props.disabled,
-            'border-neon data-[state=checked]:bg-neon data-[state=unchecked]:bg-transparent': !props.disabled,
+            'cursor-not-allowed border-primary-400': props.disabled,
+            'border-primary-600 data-[state=checked]:bg-primary-600 data-[state=unchecked]:bg-transparent':
+              !props.disabled,
           },
           className
         )}

--- a/src/renderer/src/components/Clickable.tsx
+++ b/src/renderer/src/components/Clickable.tsx
@@ -125,7 +125,7 @@ const Base = ({
   return (
     <div
       className={StyleHelper.mergeStyles(
-        'w-full gap-x-2.5 group-aria-[disabled=false]:cursor-pointer group-aria-[disabled=true]:cursor-not-allowed group-aria-[disabled=true]:opacity-50',
+        'interactive-primary w-full gap-x-2.5 group-aria-[disabled=false]:cursor-pointer group-aria-[disabled=true]:cursor-not-allowed group-aria-[disabled=true]:opacity-50',
         {
           'px-7': wide,
           'h-12 text-sm': !flat,

--- a/src/renderer/src/components/IconClickable.tsx
+++ b/src/renderer/src/components/IconClickable.tsx
@@ -93,7 +93,7 @@ const Base = ({
     <div
       {...props}
       className={StyleHelper.mergeStyles(
-        'flex h-fit flex-grow-0 flex-col items-center justify-center rounded transition-all',
+        'interactive-primary flex h-fit flex-grow-0 flex-col items-center justify-center rounded transition-all',
         {
           'gap-y-0.5 px-2 py-1': (size === 'sm' || size === 'xs') && !compacted,
           'gap-y-0.5 p-1': (size === 'sm' || size === 'xs') && compacted,

--- a/src/renderer/src/components/Input.tsx
+++ b/src/renderer/src/components/Input.tsx
@@ -134,12 +134,12 @@ export const Input = forwardRef<HTMLInputElement, TInputProps>(
         <div
           aria-disabled={isDisabled}
           className={StyleHelper.mergeStyles(
-            'flex w-full cursor-text items-center gap-x-1.5 rounded bg-asphalt px-5 font-medium text-white outline-none ring-2 ring-transparent transition-colors placeholder:text-white/50 aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+            'flex w-full cursor-text items-center gap-x-1.5 rounded bg-asphalt px-5 font-medium text-white outline-none ring-2 ring-transparent transition-colors placeholder:text-white/50 hover:bg-primary-600 active:bg-primary-600 aria-disabled:cursor-not-allowed aria-disabled:bg-primary-400 aria-disabled:opacity-50',
             {
               'h-8.5 py-1.5 text-xs': compacted,
               'h-12 py-2 text-sm': !compacted,
               'ring-pink': !!errorMessage || error === true,
-              'focus:ring-neon': !errorMessage || error === false,
+              'focus:ring-primary-600': !errorMessage || error === false,
               'pl-3': !!leftIcon,
               'pr-3': isTypePassword || clearable || pastable,
             },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,6 +18,11 @@ export default {
       neon: {
         DEFAULT: '#314AF7',
       },
+      primary: {
+        DEFAULT: '#314AF7',
+        600: '#2335C5',
+        400: '#6174F7',
+      },
       green: {
         DEFAULT: '#2EBE81',
         700: '#345048',


### PR DESCRIPTION
## Summary
- add primary color palette
- centralize hover/active/disabled styling via `interactive-primary`
- apply primary state styles across buttons, inputs, and checkboxes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a88c8052b48332b85d835af578b72e