### PR TITLE
feat: add dark theme support

### DIFF
--- a/src/renderer/src/assets/css/index.css
+++ b/src/renderer/src/assets/css/index.css
@@ -44,9 +44,26 @@
   src: url('../fonts/sofiapro-bold-webfont.woff') format('woff');
 }
 
-body {
-  width: 100vw;
-  height: 100vh;
+@layer base {
+  html {
+    color-scheme: light;
+  }
+
+  .dark {
+    color-scheme: dark;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    html {
+      color-scheme: dark;
+    }
+  }
+
+  body {
+    width: 100vw;
+    height: 100vh;
+    @apply bg-white text-gray-900 dark:bg-dark-neutral-900 dark:text-white;
+  }
 }
 
 /* width */
@@ -68,7 +85,15 @@ body {
   border: 6px solid transparent;
 }
 
+.dark ::-webkit-scrollbar-thumb {
+  background-color: theme('colors.dark.neutral.600');
+}
+
 /* Handle on hover */
 ::-webkit-scrollbar-thumb:hover {
   background-color: theme('colors.gray.600');
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background-color: theme('colors.dark.neutral.400');
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ import { Config } from 'tailwindcss'
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{ts,tsx}'],
+  darkMode: ['class', 'media'],
   theme: {
     colors: {
       transparent: 'transparent',
@@ -14,6 +15,9 @@ export default {
       },
       black: {
         DEFAULT: '#000',
+      },
+      primary: {
+        DEFAULT: '#2F41DB',
       },
       neon: {
         DEFAULT: '#314AF7',
@@ -59,6 +63,20 @@ export default {
         300: '#818D95', // mid
         200: '#C5D0D5',
         100: '#B0C0C8', //light
+      },
+      dark: {
+        primary: '#2F41DB',
+        neutral: {
+          900: '#0A0A0A',
+          800: '#171717',
+          700: '#2E2E2E',
+          600: '#404040',
+          500: '#525252',
+          400: '#737373',
+          300: '#A3A3A3',
+          200: '#D4D4D4',
+          100: '#E5E5E5',
+        },
       },
     },
     extend: {


### PR DESCRIPTION
## Summary
- define primary blue and dark neutrals with dark mode support in tailwind config
- enable class and media dark mode toggling in global styles

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aad752a01c8332ab66e9b9d36df5ab